### PR TITLE
clean test-requirements

### DIFF
--- a/named_enum/__init__.py
+++ b/named_enum/__init__.py
@@ -345,7 +345,7 @@ class NamedEnumMeta(EnumMeta):
         :return: converted value depending on the given data type
         :rtype: dict, list, set, tuple, OrderedDict_
         """
-        return data_type(cls.gen())
+        return data_type(cls.gen(name_value_pair=True))
 
     def as_dict(cls):
         """

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,5 @@
 pytest==5.4.3
 pytest-cov==2.10.0
-pytest-mock==3.1.1
 pytest-runner==5.2
 codecov==2.1.7
 coverage==5.1

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,6 +1,10 @@
-def generator_tester(generator_iterator_to_test, expected_values):
+import types
+
+
+def generator_tester(generator_to_test, expected_values):
+    assert isinstance(generator_to_test, types.GeneratorType)
     range_index = 0
-    for actual in generator_iterator_to_test:
+    for actual in generator_to_test:
         assert range_index + 1 <= len(expected_values)
         assert expected_values[range_index] == actual
         range_index += 1

--- a/tests/test_cls_LabeledEnum.py
+++ b/tests/test_cls_LabeledEnum.py
@@ -1,5 +1,5 @@
 import pytest
-from pytest_mock import mocker
+from unittest import mock
 from collections import OrderedDict
 from named_enum import LabeledEnum
 from .helper import generator_tester
@@ -11,57 +11,59 @@ class NBALegendary(LabeledEnum):
 
 
 class TestLabeledEnum:
-    def test__fields(self, mocker):
+    def test__fields(self):
         assert NBALegendary._fields() == ('key', 'label')
 
-        mocker.patch.object(NBALegendary, '_field_names_')
-        NBALegendary._field_names_ = None
-        assert NBALegendary._fields() == tuple()
+        with mock.patch.object(NBALegendary, '_field_names_',
+                               new_callable=mock.PropertyMock(return_value=None)) \
+                as mocked__field_names_:
+            assert NBALegendary._fields() == tuple()
 
-    def test_gen(self, mocker):
-        result = NBALegendary.gen(True)
-        expected_result = [
-            ('JOHNSON', NBALegendary._tuple_cls(key="Johnson", label="Magic Johnson")),
-            ('Jordan', NBALegendary._tuple_cls(key="Jordan", label="Air Jordan"))]
+    @pytest.mark.parametrize("name_value_pair, expected_result",
+                             [(True, [('JOHNSON', NBALegendary._tuple_cls(key="Johnson",
+                                                                          label="Magic Johnson")),
+                                      ('Jordan', NBALegendary._tuple_cls(key="Jordan",
+                                                                         label="Air Jordan"))]),
+                              (False, [NBALegendary.JOHNSON, NBALegendary.Jordan])])
+    def test_gen(self, name_value_pair, expected_result):
+        result = NBALegendary.gen(name_value_pair)
         generator_tester(result, expected_result)
 
-        result = NBALegendary.gen(False)
-        expected_result = [NBALegendary.JOHNSON, NBALegendary.Jordan]
-        generator_tester(result, expected_result)
+    @pytest.mark.parametrize('func_name, as_tuple, expected',
+                             [('keys', True, ("Johnson", "Jordan")),
+                              ('keys', False, ("Johnson", "Jordan")),
+                              ('labels', True, ("Magic Johnson", "Air Jordan")),
+                              ('labels', False, ("Magic Johnson", "Air Jordan"))])
+    @mock.patch.object(NBALegendary, 'gen', side_effect=NBALegendary.gen)
+    def test__field_values(self, mocked_gen, func_name, as_tuple, expected):
+        result = getattr(NBALegendary, func_name)(as_tuple)
+        if as_tuple:
+            assert result == expected
+        else:
+            generator_tester(result, expected)
+        mocked_gen.assert_called_once_with(name_value_pair=False)
 
-    @pytest.mark.parametrize('func_name, expected',
-                             [('keys', ("Johnson", "Jordan")),
-                              ('labels', ("Magic Johnson", "Air Jordan"))])
-    def test__field_values(self, mocker, func_name, expected):
-        mocker.spy(NBALegendary, 'gen')
-        result = getattr(NBALegendary, func_name)(True)
-        assert result == expected
-        assert NBALegendary.gen.call_count == 1
-        NBALegendary.gen.assert_called_with(name_value_pair=False)
-
-        result = getattr(NBALegendary, func_name)(False)
-        generator_tester(result, expected)
-        assert NBALegendary.gen.call_count == 2
-        NBALegendary.gen.assert_called_with(name_value_pair=False)
-
-    @pytest.mark.parametrize('func_name, value, expected',
-                             [('from_key', "Johnson", (NBALegendary.JOHNSON, )),
-                              ('from_key', "Jordan", (NBALegendary.Jordan, )),
-                              ('from_key', "Johnsonmy", tuple()),
-                              ('from_label', "Magic Johnson", (NBALegendary.JOHNSON, )),
-                              ('from_label', "Air Jordan", (NBALegendary.Jordan, )),
-                              ('from_label', "Micheal", tuple())])
-    def test__from_field(self, mocker, func_name, value, expected):
-        mocker.spy(NBALegendary, 'gen')
-        result = getattr(NBALegendary, func_name)(value, True)
-        assert result == expected
-        assert NBALegendary.gen.call_count == 1
-        NBALegendary.gen.assert_called_with(name_value_pair=False)
-
-        result = getattr(NBALegendary, func_name)(value, False)
-        generator_tester(result, expected)
-        assert NBALegendary.gen.call_count == 2
-        NBALegendary.gen.assert_called_with(name_value_pair=False)
+    @pytest.mark.parametrize('func_name, value, as_tuple, expected',
+                             [('from_key', "Johnson", True, (NBALegendary.JOHNSON, )),
+                              ('from_key', "Johnson", False, (NBALegendary.JOHNSON,)),
+                              ('from_key', "Jordan", True, (NBALegendary.Jordan, )),
+                              ('from_key', "Jordan", False, (NBALegendary.Jordan, )),
+                              ('from_key', "Johnsonmy", True, tuple()),
+                              ('from_key', "Johnsonmy", False, tuple()),
+                              ('from_label', "Magic Johnson", True, (NBALegendary.JOHNSON, )),
+                              ('from_label', "Magic Johnson", False, (NBALegendary.JOHNSON, )),
+                              ('from_label', "Air Jordan", True, (NBALegendary.Jordan, )),
+                              ('from_label', "Air Jordan", False, (NBALegendary.Jordan, )),
+                              ('from_label', "Micheal", True, tuple()),
+                              ('from_label', "Micheal", False, tuple())])
+    @mock.patch.object(NBALegendary, 'gen', side_effect=NBALegendary.gen)
+    def test__from_field(self, mocked_gen, func_name, value, as_tuple, expected):
+        result = getattr(NBALegendary, func_name)(value, as_tuple)
+        if as_tuple:
+            assert result == expected
+        else:
+            generator_tester(result, expected)
+        mocked_gen.assert_called_once_with(name_value_pair=False)
 
     @pytest.mark.parametrize('func_name, value, expected',
                              [('has_key', "Johnson", True),
@@ -70,12 +72,11 @@ class TestLabeledEnum:
                               ('has_label', "Magic Johnson", True),
                               ('has_label', "Air Jordan", True),
                               ('has_label', "Micheal", False)])
-    def test__has_field(self, mocker, func_name, value, expected):
-        mocker.spy(NBALegendary, 'gen')
+    @mock.patch.object(NBALegendary, 'gen', side_effect=NBALegendary.gen)
+    def test__has_field(self, mocked_gen, func_name, value, expected):
         result = getattr(NBALegendary, func_name)(value)
         assert result == expected
-        assert NBALegendary.gen.call_count == 1
-        NBALegendary.gen.assert_called_with(name_value_pair=False)
+        mocked_gen.assert_called_once_with(name_value_pair=False)
 
     @pytest.mark.parametrize('func_name, func_param, error_type',
                              [('forths', (True, ), AttributeError),
@@ -83,57 +84,88 @@ class TestLabeledEnum:
                               ('from_forth', ("Johnson", True), AttributeError),
                               ('from_forth', ("Johnson", False), AttributeError),
                               ('has_forth', ("Johnson", True), AttributeError),
-                              ('has_forth', ("Johnson", False), AttributeError),
-                              ])
+                              ('has_forth', ("Johnson", False), AttributeError)])
     def test__func_fail(self, func_name, func_param, error_type):
         with pytest.raises(error_type) as excinfo:
             getattr(NBALegendary, func_name)(*func_param)
         assert func_name == str(excinfo.value)
 
     @pytest.mark.parametrize("data_type, expected",
-                             [(dict, {'JOHNSON': NBALegendary._tuple_cls(key="Johnson", label="Magic Johnson"), 'Jordan': NBALegendary._tuple_cls(key="Jordan", label="Air Jordan")}),
-                              (list, [('JOHNSON', NBALegendary._tuple_cls(key="Johnson", label="Magic Johnson")), ('Jordan', NBALegendary._tuple_cls(key="Jordan", label="Air Jordan"))]),
-                              (set, {('JOHNSON', NBALegendary._tuple_cls(key="Johnson", label="Magic Johnson")), ('Jordan', NBALegendary._tuple_cls(key="Jordan", label="Air Jordan"))}),
-                              (tuple, (('JOHNSON', NBALegendary._tuple_cls(key="Johnson", label="Magic Johnson")), ('Jordan', NBALegendary._tuple_cls(key="Jordan", label="Air Jordan")))),
-                              (OrderedDict, OrderedDict([('JOHNSON', NBALegendary._tuple_cls(key="Johnson", label="Magic Johnson")), ('Jordan', NBALegendary._tuple_cls(key="Jordan", label="Air Jordan"))]))])
-    def test__as_data_type(self, mocker, data_type, expected):
-        mocker.spy(NBALegendary, 'gen')
+                             [(dict, {'JOHNSON': NBALegendary._tuple_cls(key="Johnson",
+                                                                         label="Magic Johnson"),
+                                      'Jordan': NBALegendary._tuple_cls(key="Jordan",
+                                                                        label="Air Jordan")}),
+                              (list, [('JOHNSON', NBALegendary._tuple_cls(key="Johnson",
+                                                                          label="Magic Johnson")),
+                                      ('Jordan', NBALegendary._tuple_cls(key="Jordan",
+                                                                         label="Air Jordan"))]),
+                              (set, {('JOHNSON', NBALegendary._tuple_cls(key="Johnson",
+                                                                         label="Magic Johnson")),
+                                     ('Jordan', NBALegendary._tuple_cls(key="Jordan",
+                                                                        label="Air Jordan"))}),
+                              (tuple, (('JOHNSON', NBALegendary._tuple_cls(key="Johnson",
+                                                                           label="Magic Johnson")),
+                                       ('Jordan', NBALegendary._tuple_cls(key="Jordan",
+                                                                          label="Air Jordan")))),
+                              (OrderedDict, OrderedDict([
+                                  ('JOHNSON', NBALegendary._tuple_cls(key="Johnson",
+                                                                      label="Magic Johnson")),
+                                  ('Jordan', NBALegendary._tuple_cls(key="Jordan",
+                                                                     label="Air Jordan"))]))])
+    @mock.patch.object(NBALegendary, 'gen', side_effect=NBALegendary.gen)
+    def test__as_data_type(self, mocked_gen, data_type, expected):
         result = NBALegendary._as_data_type(data_type)
         assert result == expected
-        assert NBALegendary.gen.call_count == 1
-        NBALegendary.gen.assert_called_with()
+        mocked_gen.assert_called_once_with(name_value_pair=True)
 
     @pytest.mark.parametrize("func_name, expected",
-                             [("as_dict", {'JOHNSON': NBALegendary._tuple_cls(key="Johnson", label="Magic Johnson"), 'Jordan': NBALegendary._tuple_cls(key="Jordan", label="Air Jordan")}),
-                              ("as_list", [('JOHNSON', NBALegendary._tuple_cls(key="Johnson", label="Magic Johnson")), ('Jordan', NBALegendary._tuple_cls(key="Jordan", label="Air Jordan"))]),
-                              ("as_set", {('JOHNSON', NBALegendary._tuple_cls(key="Johnson", label="Magic Johnson")), ('Jordan', NBALegendary._tuple_cls(key="Jordan", label="Air Jordan"))}),
-                              ("as_tuple", (('JOHNSON', NBALegendary._tuple_cls(key="Johnson", label="Magic Johnson")), ('Jordan', NBALegendary._tuple_cls(key="Jordan", label="Air Jordan")))),
-                              ("as_ordereddict", OrderedDict([('JOHNSON', NBALegendary._tuple_cls(key="Johnson", label="Magic Johnson")), ('Jordan', NBALegendary._tuple_cls(key="Jordan", label="Air Jordan"))]))])
-    def test_as_x(self, mocker, func_name, expected):
-        mocker.spy(NBALegendary, '_as_data_type')
+                             [("as_dict", {'JOHNSON': NBALegendary._tuple_cls(key="Johnson",
+                                                                              label="Magic Johnson"),
+                                           'Jordan': NBALegendary._tuple_cls(key="Jordan",
+                                                                             label="Air Jordan")}),
+                              ("as_list", [('JOHNSON', NBALegendary._tuple_cls(key="Johnson",
+                                                                               label="Magic Johnson")),
+                                           ('Jordan', NBALegendary._tuple_cls(key="Jordan",
+                                                                              label="Air Jordan"))]),
+                              ("as_set", {('JOHNSON', NBALegendary._tuple_cls(key="Johnson",
+                                                                              label="Magic Johnson")),
+                                          ('Jordan', NBALegendary._tuple_cls(key="Jordan",
+                                                                             label="Air Jordan"))}),
+                              ("as_tuple", (('JOHNSON', NBALegendary._tuple_cls(key="Johnson",
+                                                                                label="Magic Johnson")),
+                                            ('Jordan', NBALegendary._tuple_cls(key="Jordan",
+                                                                               label="Air Jordan")))),
+                              ("as_ordereddict", OrderedDict([
+                                  ('JOHNSON', NBALegendary._tuple_cls(key="Johnson",
+                                                                      label="Magic Johnson")),
+                                  ('Jordan', NBALegendary._tuple_cls(key="Jordan",
+                                                                     label="Air Jordan"))]))])
+    @mock.patch.object(NBALegendary, '_as_data_type', side_effect=NBALegendary._as_data_type)
+    def test_as_x(self, mocked__as_data_type, func_name, expected):
         result = getattr(NBALegendary, func_name)()
         assert result == expected
-        assert NBALegendary._as_data_type.call_count == 1
-        NBALegendary._as_data_type.assert_called_with(type(expected))
+        mocked__as_data_type.assert_called_once_with(type(expected))
 
-    def test___repr__(self, mocker):
-        mocker.spy(type(NBALegendary), '__repr__')
+    @mock.patch.object(type(NBALegendary), "__repr__",
+                       side_effect=type(NBALegendary).__repr__, autospec=True)
+    def test___repr__(self, mocked_repr):
         assert repr(NBALegendary) == "<named enum 'NBALegendary'>"
-        assert type(NBALegendary).__repr__.call_count == 1
+        assert mocked_repr.call_count == 1
         assert str(NBALegendary) == "<named enum 'NBALegendary'>"
-        assert type(NBALegendary).__repr__.call_count == 2
+        assert mocked_repr.call_count == 2
 
-    def test___str__(self, mocker):
-        mocker.spy(NBALegendary, '__str__')
+    @mock.patch.object(NBALegendary, "__str__", side_effect=NBALegendary.__str__,
+                       autospec=True)
+    def test___str__(self, mocked_str):
         result = str(NBALegendary.Jordan)
         assert result == "NBALegendary.Jordan: NamedTuple(key='Jordan', " \
                          "label='Air Jordan')"
-        assert NBALegendary.__str__.call_count == 1
+        assert mocked_str.call_count == 1
 
         result = str(NBALegendary.JOHNSON)
         assert result == "NBALegendary.JOHNSON: NamedTuple(key='Johnson', " \
                          "label='Magic Johnson')"
-        assert NBALegendary.__str__.call_count == 2
+        assert mocked_str.call_count == 2
 
     def test_describe(self, capsys):
         NBALegendary.describe()
@@ -143,21 +175,26 @@ class TestLabeledEnum:
                       "JOHNSON | Johnson | Magic Johnson\n" \
                       " Jordan |  Jordan |    Air Jordan\n\n"
 
-    def test_names(self, mocker):
-        result = NBALegendary.names(True)
-        assert result == ('JOHNSON', 'Jordan')
+    @pytest.mark.parametrize("as_tuple", [True, False])
+    def test_names(self, as_tuple):
+        expected_result = ('JOHNSON', 'Jordan')
+        result = NBALegendary.names(as_tuple)
+        if as_tuple:
+            assert result == expected_result
+        else:
+            generator_tester(result, expected_result)
 
-        result = NBALegendary.names(False)
-        generator_tester(result, ('JOHNSON', 'Jordan'))
-
-    def test_values(self, mocker):
-        expected = (NBALegendary._tuple_cls(key="Johnson", label="Magic Johnson"),
-                    NBALegendary._tuple_cls(key="Jordan", label="Air Jordan"))
-        result = NBALegendary.values(True)
-        assert result == expected
-
-        result = NBALegendary.values(False)
-        generator_tester(result, expected)
+    @pytest.mark.parametrize("as_tuple", [True, False])
+    def test_values(self, as_tuple):
+        expected_result = (NBALegendary._tuple_cls(key="Johnson",
+                                                   label="Magic Johnson"),
+                           NBALegendary._tuple_cls(key="Jordan",
+                                                   label="Air Jordan"))
+        result = NBALegendary.values(as_tuple)
+        if as_tuple:
+            assert result == expected_result
+        else:
+            generator_tester(result, expected_result)
 
     def test___getattr__(self):
         result = getattr(NBALegendary.Jordan, 'key')

--- a/tests/test_cls_NamedEnum.py
+++ b/tests/test_cls_NamedEnum.py
@@ -1,5 +1,5 @@
 import pytest
-from pytest_mock import mocker
+from unittest import mock
 from collections import OrderedDict
 from named_enum import NamedEnum
 from .helper import generator_tester
@@ -17,65 +17,71 @@ class Triangle(TripleEnum):
 class TestNamedEnum:
     def test___new__(self):
         with pytest.raises(AttributeError) as exe_info:
-            class TripleFakeEnum(NamedEnum):
-                _field_names_ = ("name, value, key")
+            type("TripleFakeEnum", (NamedEnum, ),
+                 {'_field_names_': ("name, value, key")})
         assert "'name' or 'value' cannot be attributes" == str(exe_info.value)
 
-    def test__fields(self, mocker):
+    def test__fields(self):
         assert Triangle._fields() == ('first', 'second', 'third')
 
-        mocker.patch.object(Triangle, '_field_names_')
-        Triangle._field_names_ = None
-        assert Triangle._fields() == tuple()
+        with mock.patch.object(Triangle, '_field_names_',
+                               new_callable=mock.PropertyMock(return_value=None)) \
+                as mocked__field_names_:
+            assert Triangle._fields() == tuple()
 
-    def test_gen(self, mocker):
-        result = Triangle.gen(True)
-        expected_result = [
-            ('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)),
-            ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))]
+    @pytest.mark.parametrize("name_value_pair, expected_result",
+                             [(True, [('EQUILATERAL',
+                                       Triangle._tuple_cls(first=6, second=6, third=6)),
+                                      ('RIGHT',
+                                       Triangle._tuple_cls(first=3, second=4, third=5))]),
+                              (False, [Triangle.EQUILATERAL, Triangle.RIGHT])])
+    def test_gen(self, name_value_pair, expected_result):
+        result = Triangle.gen(name_value_pair)
         generator_tester(result, expected_result)
 
-        result = Triangle.gen(False)
-        expected_result = [Triangle.EQUILATERAL, Triangle.RIGHT]
-        generator_tester(result, expected_result)
+    @pytest.mark.parametrize('func_name, as_tuple, expected',
+                             [('firsts', True, (6, 3)),
+                              ('firsts', False, (6, 3)),
+                              ('seconds', True, (6, 4)),
+                              ('seconds', False, (6, 4)),
+                              ('thirds', True, (6, 5)),
+                              ('thirds', False, (6, 5))])
+    @mock.patch.object(Triangle, 'gen', side_effect=Triangle.gen)
+    def test__field_values(self, mocked_gen, func_name, as_tuple, expected):
+        result = getattr(Triangle, func_name)(as_tuple)
+        if as_tuple:
+            assert result == expected
+        else:
+            generator_tester(result, expected)
+        mocked_gen.assert_called_once_with(name_value_pair=False)
 
-    @pytest.mark.parametrize('func_name, expected',
-                             [('firsts', (6, 3)),
-                              ('seconds', (6, 4)),
-                              ('thirds', (6, 5))])
-    def test__field_values(self, mocker, func_name, expected):
-        mocker.spy(Triangle, 'gen')
-        result = getattr(Triangle, func_name)(True)
-        assert result == expected
-        assert Triangle.gen.call_count == 1
-        Triangle.gen.assert_called_with(name_value_pair=False)
-
-        result = getattr(Triangle, func_name)(False)
-        generator_tester(result, expected)
-        assert Triangle.gen.call_count == 2
-        Triangle.gen.assert_called_with(name_value_pair=False)
-
-    @pytest.mark.parametrize('func_name, value, expected',
-                             [('from_first', 6, (Triangle.EQUILATERAL, )),
-                              ('from_first', 3, (Triangle.RIGHT, )),
-                              ('from_first', 63, tuple()),
-                              ('from_second', 6, (Triangle.EQUILATERAL, )),
-                              ('from_second', 4, (Triangle.RIGHT, )),
-                              ('from_second', 64, tuple()),
-                              ('from_third', 6, (Triangle.EQUILATERAL, )),
-                              ('from_third', 5, (Triangle.RIGHT, )),
-                              ('from_third', 65, tuple())])
-    def test__from_field(self, mocker, func_name, value, expected):
-        mocker.spy(Triangle, 'gen')
-        result = getattr(Triangle, func_name)(value, True)
-        assert result == expected
-        assert Triangle.gen.call_count == 1
-        Triangle.gen.assert_called_with(name_value_pair=False)
-
-        result = getattr(Triangle, func_name)(value, False)
-        generator_tester(result, expected)
-        assert Triangle.gen.call_count == 2
-        Triangle.gen.assert_called_with(name_value_pair=False)
+    @pytest.mark.parametrize('func_name, value, as_tuple, expected',
+                             [('from_first', 6, True, (Triangle.EQUILATERAL, )),
+                              ('from_first', 6, False, (Triangle.EQUILATERAL,)),
+                              ('from_first', 3, True, (Triangle.RIGHT, )),
+                              ('from_first', 3, False, (Triangle.RIGHT,)),
+                              ('from_first', 63, True, tuple()),
+                              ('from_first', 63, False, tuple()),
+                              ('from_second', 6, True, (Triangle.EQUILATERAL, )),
+                              ('from_second', 6, False, (Triangle.EQUILATERAL,)),
+                              ('from_second', 4, True, (Triangle.RIGHT, )),
+                              ('from_second', 4, False, (Triangle.RIGHT, )),
+                              ('from_second', 64, True, tuple()),
+                              ('from_second', 64, False, tuple()),
+                              ('from_third', 6, True, (Triangle.EQUILATERAL, )),
+                              ('from_third', 6, False, (Triangle.EQUILATERAL, )),
+                              ('from_third', 5, True, (Triangle.RIGHT, )),
+                              ('from_third', 5, False, (Triangle.RIGHT, )),
+                              ('from_third', 65, True, tuple()),
+                              ('from_third', 65, False, tuple())])
+    @mock.patch.object(Triangle, 'gen', side_effect=Triangle.gen)
+    def test__from_field(self, mocked_gen, func_name, value, as_tuple, expected):
+        result = getattr(Triangle, func_name)(value, as_tuple)
+        if as_tuple:
+            assert result == expected
+        else:
+            generator_tester(result, expected)
+        mocked_gen.assert_called_once_with(name_value_pair=False)
 
     @pytest.mark.parametrize('func_name, value, expected',
                              [('has_first', 6, True),
@@ -87,12 +93,11 @@ class TestNamedEnum:
                               ('has_third', 6, True),
                               ('has_third', 5, True),
                               ('has_third', 65, False)])
-    def test__has_field(self, mocker, func_name, value, expected):
-        mocker.spy(Triangle, 'gen')
+    @mock.patch.object(Triangle, 'gen', side_effect=Triangle.gen)
+    def test__has_field(self, mocked_gen, func_name, value, expected):
         result = getattr(Triangle, func_name)(value)
         assert result == expected
-        assert Triangle.gen.call_count == 1
-        Triangle.gen.assert_called_with(name_value_pair=False)
+        mocked_gen.assert_called_once_with(name_value_pair=False)
 
     @pytest.mark.parametrize('func_name, func_param, error_type',
                              [('forths', (True, ), AttributeError),
@@ -108,49 +113,61 @@ class TestNamedEnum:
         assert func_name == str(excinfo.value)
 
     @pytest.mark.parametrize("data_type, expected",
-                             [(dict, {'EQUILATERAL': Triangle._tuple_cls(first=6, second=6, third=6), 'RIGHT': Triangle._tuple_cls(first=3, second=4, third=5)}),
-                              (list, [('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)), ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))]),
-                              (set, {('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)), ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))}),
-                              (tuple, (('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)), ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5)))),
-                              (OrderedDict, OrderedDict([('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)), ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))]))])
-    def test__as_data_type(self, mocker, data_type, expected):
-        mocker.spy(Triangle, 'gen')
+                             [(dict, {'EQUILATERAL': Triangle._tuple_cls(first=6, second=6, third=6),
+                                      'RIGHT': Triangle._tuple_cls(first=3, second=4, third=5)}),
+                              (list, [('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)),
+                                      ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))]),
+                              (set, {('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)),
+                                     ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))}),
+                              (tuple, (('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)),
+                                       ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5)))),
+                              (OrderedDict, OrderedDict([
+                                  ('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)),
+                                  ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))]))])
+    @mock.patch.object(Triangle, 'gen', side_effect=Triangle.gen)
+    def test__as_data_type(self, mocked_gen, data_type, expected):
         result = Triangle._as_data_type(data_type)
         assert result == expected
-        assert Triangle.gen.call_count == 1
-        Triangle.gen.assert_called_with()
+        mocked_gen.assert_called_once_with(name_value_pair=True)
 
     @pytest.mark.parametrize("func_name, expected",
-                             [("as_dict", {'EQUILATERAL': Triangle._tuple_cls(first=6, second=6, third=6), 'RIGHT': Triangle._tuple_cls(first=3, second=4, third=5)}),
-                              ("as_list", [('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)), ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))]),
-                              ("as_set", {('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)), ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))}),
-                              ("as_tuple", (('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)), ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5)))),
-                              ("as_ordereddict", OrderedDict([('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)), ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))]))])
-    def test_as_x(self, mocker, func_name, expected):
-        mocker.spy(Triangle, '_as_data_type')
+                             [("as_dict", {'EQUILATERAL': Triangle._tuple_cls(first=6, second=6, third=6),
+                                           'RIGHT': Triangle._tuple_cls(first=3, second=4, third=5)}),
+                              ("as_list", [('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)),
+                                           ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))]),
+                              ("as_set", {('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)),
+                                          ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))}),
+                              ("as_tuple", (('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)),
+                                            ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5)))),
+                              ("as_ordereddict", OrderedDict([
+                                  ('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)),
+                                  ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))]))])
+    @mock.patch.object(Triangle, '_as_data_type', side_effect=Triangle._as_data_type)
+    def test_as_x(self, mocked__as_data_type, func_name, expected):
         result = getattr(Triangle, func_name)()
         assert result == expected
-        assert Triangle._as_data_type.call_count == 1
-        Triangle._as_data_type.assert_called_with(type(expected))
+        mocked__as_data_type.assert_called_once_with(type(expected))
 
-    def test___repr__(self, mocker):
-        mocker.spy(type(Triangle), '__repr__')
+    @mock.patch.object(type(Triangle), "__repr__",
+                       side_effect=type(Triangle).__repr__, autospec=True)
+    def test___repr__(self, mocked_repr):
         assert repr(Triangle) == "<named enum 'Triangle'>"
-        assert type(Triangle).__repr__.call_count == 1
+        assert mocked_repr.call_count == 1
         assert str(Triangle) == "<named enum 'Triangle'>"
-        assert type(Triangle).__repr__.call_count == 2
+        assert mocked_repr.call_count == 2
 
-    def test___str__(self, mocker):
-        mocker.spy(Triangle, '__str__')
+    @mock.patch.object(Triangle, "__str__", side_effect=Triangle.__str__,
+                       autospec=True)
+    def test___str__(self, mocked_str):
         result = str(Triangle.RIGHT)
         assert result == "Triangle.RIGHT: NamedTuple(first=3, second=4, " \
                          "third=5)"
-        assert Triangle.__str__.call_count == 1
+        assert mocked_str.call_count == 1
 
         result = str(Triangle.EQUILATERAL)
         assert result == "Triangle.EQUILATERAL: NamedTuple(first=6, second=6, " \
                          "third=6)"
-        assert Triangle.__str__.call_count == 2
+        assert mocked_str.call_count == 2
 
     def test_describe(self, capsys):
         Triangle.describe()
@@ -160,21 +177,24 @@ class TestNamedEnum:
                       "    6 |      6 |     6\n      RIGHT |     3 |      4 |" \
                       "     5\n\n"
 
-    def test_names(self, mocker):
-        result = Triangle.names(True)
-        assert result == ('EQUILATERAL', 'RIGHT')
+    @pytest.mark.parametrize("as_tuple", [True, False])
+    def test_names(self, as_tuple):
+        expected_result = ('EQUILATERAL', 'RIGHT')
+        result = Triangle.names(as_tuple)
+        if as_tuple:
+            assert result == expected_result
+        else:
+            generator_tester(result, expected_result)
 
-        result = Triangle.names(False)
-        generator_tester(result, ('EQUILATERAL', 'RIGHT'))
-
-    def test_values(self, mocker):
-        expected = (Triangle._tuple_cls(first=6, second=6, third=6),
-                    Triangle._tuple_cls(first=3, second=4, third=5))
-        result = Triangle.values(True)
-        assert result == expected
-
-        result = Triangle.values(False)
-        generator_tester(result, expected)
+    @pytest.mark.parametrize("as_tuple", [True, False])
+    def test_values(self, as_tuple):
+        expected_result = (Triangle._tuple_cls(first=6, second=6, third=6),
+                           Triangle._tuple_cls(first=3, second=4, third=5))
+        result = Triangle.values(as_tuple)
+        if as_tuple:
+            assert result == expected_result
+        else:
+            generator_tester(result, expected_result)
 
     def test___getattr__(self):
         result = getattr(Triangle.RIGHT, 'first')

--- a/tests/test_cls_NamedEnumMeta.py
+++ b/tests/test_cls_NamedEnumMeta.py
@@ -1,8 +1,7 @@
 import pytest
-from pytest_mock import mocker
+from unittest import mock
 from enum import Enum
 from collections import OrderedDict, namedtuple
-from unittest.mock import Mock
 from named_enum import NamedEnumMeta, _NamedEnumDict
 from .helper import generator_tester
 
@@ -13,45 +12,53 @@ class Color(Enum):
 
 
 class MockColor(Enum):
-    red = Mock(a=1)
-    blue = Mock(a=2)
+    red = mock.Mock(a=1)
+    blue = mock.Mock(a=2)
 
 
 class TestNamedEnumMeta:
 
-    def test___prepare__(self, mocker):
-        mocker.patch.object(NamedEnumMeta, '_get_mixins_')
-        NamedEnumMeta._get_mixins_.return_value = (None, None)
+    @mock.patch.object(NamedEnumMeta, '_get_mixins_')
+    def test___prepare__(self, mocked__get_mixins_):
+        mocked__get_mixins_.return_value = (None, None)
+
         result = NamedEnumMeta.__prepare__("dummy", ())
         expected_result = _NamedEnumDict()
         assert isinstance(result, _NamedEnumDict)
         assert result == expected_result
-        NamedEnumMeta._get_mixins_.assert_called_with(tuple())
+        mocked__get_mixins_.assert_called_once_with(tuple())
 
-        first_enum = Mock(spec=[])
-        NamedEnumMeta._get_mixins_.return_value = (None, first_enum)
+        mocked__get_mixins_.reset_mock()
+
+        first_enum = mock.Mock(spec=[])
+        mocked__get_mixins_.return_value = (None, first_enum)
+
         result = NamedEnumMeta.__prepare__("dummy", ())
-
         expected_result['_generate_next_value_'] = None
         assert isinstance(result, _NamedEnumDict)
         assert result == expected_result
-        NamedEnumMeta._get_mixins_.assert_called_with(tuple())
+        mocked__get_mixins_.assert_called_once_with(tuple())
 
-        first_enum = Mock(spec=['_generate_next_value_'],
-                          _generate_next_value_=1)
-        NamedEnumMeta._get_mixins_.return_value =(None, first_enum)
+        mocked__get_mixins_.reset_mock()
+
+        first_enum = mock.Mock(spec=['_generate_next_value_'],
+                               _generate_next_value_=1)
+        mocked__get_mixins_.return_value =(None, first_enum)
+
         result = NamedEnumMeta.__prepare__("dummy", ())
         expected_result['_generate_next_value_'] = 1
         assert isinstance(result, _NamedEnumDict)
         assert result == expected_result
-        NamedEnumMeta._get_mixins_.assert_called_with(tuple())
+        mocked__get_mixins_.assert_called_once_with(tuple())
 
     @pytest.mark.parametrize('_field_names_, expected',
-                             [(None, tuple()), ("ha", ('key', 'value'))])
-    def test__fields(self, mocker, _field_names_, expected):
-        mocker.patch.object(NamedEnumMeta, '_tuple_cls', create=True)
+                             [(None, tuple()),
+                              ("ha", ('key', 'value'))])
+    @mock.patch.object(NamedEnumMeta, '_tuple_cls', create=True)
+    @mock.patch.object(NamedEnumMeta, '_field_names_', create=True)
+    def test__fields(self, mocked__field_names_, mocked__tuple_cls,
+                     _field_names_, expected):
         NamedEnumMeta._tuple_cls = namedtuple("nt", "key, value")
-        mocker.patch.object(NamedEnumMeta, '_field_names_', create=True)
         NamedEnumMeta._field_names_ = _field_names_
 
         result = NamedEnumMeta._fields(NamedEnumMeta)
@@ -60,50 +67,51 @@ class TestNamedEnumMeta:
     @pytest.mark.parametrize('params, expected',
                              [((True, ), [('red', 1), ('blue', 2)]),
                               ((False, ), [Color.red, Color.blue])])
-    def test_gen(self, mocker, params, expected):
-        mocker.patch.object(NamedEnumMeta, '_member_map_', create=True)
-        NamedEnumMeta._member_map_ = Color._member_map_
-
+    @mock.patch.object(NamedEnumMeta, '_member_map_', create=True,
+                       new_callable=mock.PropertyMock(return_value=Color._member_map_))
+    def test_gen(self, mocked__member_map_, params, expected):
         result = NamedEnumMeta.gen(NamedEnumMeta, *params)
         generator_tester(result, expected)
 
-    def test__field_values(self, mocker):
-        mocker.patch.object(NamedEnumMeta, 'gen')
-        NamedEnumMeta.gen.return_value = (item for item in MockColor)
+    @mock.patch.object(NamedEnumMeta, 'gen')
+    def test__field_values(self, mocked_gen):
+        mocked_gen.return_value = (item for item in MockColor)
         result = NamedEnumMeta._field_values(NamedEnumMeta, 'a', True)
         expected = (1, 2)
         assert result == expected
-        NamedEnumMeta.gen.assert_called_with(name_value_pair=False)
+        mocked_gen.assert_called_once_with(name_value_pair=False)
 
-        NamedEnumMeta.gen.return_value = (item for item in MockColor)
+        mocked_gen.reset_mock()
+
+        mocked_gen.return_value = (item for item in MockColor)
         result = NamedEnumMeta._field_values(NamedEnumMeta, 'a', False)
         generator_tester(result, expected)
-        NamedEnumMeta.gen.assert_called_with(name_value_pair=False)
+        mocked_gen.assert_called_once_with(name_value_pair=False)
 
     @pytest.mark.parametrize('params, expected',
-                             [(('a', 1), (MockColor.red, )),
-                              (('a', 3), tuple())])
-    def test__from_field(self, mocker, params, expected):
-        mocker.patch.object(NamedEnumMeta, 'gen')
-        NamedEnumMeta.gen.return_value = (item for item in MockColor)
-        result = NamedEnumMeta._from_field(NamedEnumMeta, *params, True)
-        assert result == expected
-        NamedEnumMeta.gen.assert_called_with(name_value_pair=False)
-
-        NamedEnumMeta.gen.return_value = (item for item in MockColor)
-        result = NamedEnumMeta._from_field(NamedEnumMeta, *params, False)
-        generator_tester(result, expected)
-        NamedEnumMeta.gen.assert_called_with(name_value_pair=False)
+                             [(dict(field_name='a', field_value=1, as_tuple=True), (MockColor.red, )),
+                              (dict(field_name='a', field_value=1, as_tuple=False), (MockColor.red,)),
+                              (dict(field_name='a', field_value=3, as_tuple=True), tuple()),
+                              (dict(field_name='a', field_value=3, as_tuple=False), tuple())])
+    @mock.patch.object(NamedEnumMeta, 'gen',
+                       side_effect=lambda name_value_pair: (item for item in MockColor))
+    def test__from_field(self, mocked_gen, params, expected):
+        result = NamedEnumMeta._from_field(NamedEnumMeta, **params)
+        if params["as_tuple"]:
+            assert result == expected
+        else:
+            generator_tester(result, expected)
+        mocked_gen.assert_called_with(name_value_pair=False)
 
     @pytest.mark.parametrize('params, expected',
                              [(('a', 1), True),
                               (('a', 3), False)])
-    def test__has_field(self, mocker, params, expected):
-        mocker.patch.object(NamedEnumMeta, 'gen')
-        NamedEnumMeta.gen.return_value = (item for item in MockColor)
+    @mock.patch.object(NamedEnumMeta, 'gen',
+                       return_value=(item for item in MockColor))
+    def test__has_field(self, mocked_gen, params, expected):
         result = NamedEnumMeta._has_field(NamedEnumMeta, *params)
         assert result == expected
-        NamedEnumMeta.gen.assert_called_with(name_value_pair=False)
+        mocked_gen.assert_called_once_with(name_value_pair=False)
 
     @pytest.mark.parametrize("data_type, expected",
                              [(dict, {'red': 1, 'blue': 2}),
@@ -111,13 +119,12 @@ class TestNamedEnumMeta:
                               (set, {('red', 1), ('blue', 2)}),
                               (tuple, (('red', 1), ('blue', 2))),
                               (OrderedDict, OrderedDict([('red', 1), ('blue', 2)]))])
-    def test__as_data_type(self, mocker, data_type, expected):
-        mocker.patch.object(NamedEnumMeta, 'gen')
-        NamedEnumMeta.gen.return_value = ((item.name, item.value)
-                                          for item in Color)
+    @mock.patch.object(NamedEnumMeta, 'gen',
+                       side_effect=lambda name_value_pair: ((item.name, item.value) for item in Color))
+    def test__as_data_type(self, mocked_gen, data_type, expected):
         result = NamedEnumMeta._as_data_type(NamedEnumMeta, data_type)
         assert result == expected
-        NamedEnumMeta.gen.assert_called_with()
+        mocked_gen.assert_called_once_with(name_value_pair=True)
 
     @pytest.mark.parametrize("func_name, expected",
                              [("as_dict", {'red': 1, 'blue': 2}),
@@ -125,34 +132,35 @@ class TestNamedEnumMeta:
                               ("as_set", {('red', 1), ('blue', 2)}),
                               ("as_tuple", (('red', 1), ('blue', 2))),
                               ("as_ordereddict", OrderedDict([('red', 1), ('blue', 2)]))])
-    def test_as_x(self, mocker, func_name, expected):
-        mocker.patch.object(NamedEnumMeta, '_as_data_type')
-        NamedEnumMeta._as_data_type.side_effect = lambda data_type: \
-            data_type((item.name, item.value) for item in Color)
+    @mock.patch.object(NamedEnumMeta, '_as_data_type',
+                       side_effect=lambda data_type: data_type((item.name, item.value) for item in Color))
+    def test_as_x(self, mocked__as_data_type, func_name, expected):
         result = getattr(NamedEnumMeta, func_name)(NamedEnumMeta)
         assert result == expected
-        NamedEnumMeta._as_data_type.assert_called_with(type(expected))
+        mocked__as_data_type.assert_called_once_with(type(expected))
 
     def test___repr__(self):
         result = NamedEnumMeta.__repr__(NamedEnumMeta)
         assert result == "<named enum 'NamedEnumMeta'>"
 
-    def test_names(self, mocker):
-        mocker.patch.object(NamedEnumMeta, '_member_map_', create=True)
-        NamedEnumMeta._member_map_ = Color._member_map_
+    @pytest.mark.parametrize("as_tuple", [True, False])
+    @mock.patch.object(NamedEnumMeta, '_member_map_', create=True,
+                       new_callable=mock.PropertyMock(return_value=Color._member_map_))
+    def test_names(self, mocked__member_map_, as_tuple):
+        expected_result = ('red', 'blue')
+        result = NamedEnumMeta.names(NamedEnumMeta, as_tuple)
+        if as_tuple:
+            assert result == expected_result
+        else:
+            generator_tester(result, expected_result)
 
-        result = NamedEnumMeta.names(NamedEnumMeta, True)
-        assert result == ('red', 'blue')
-
-        result = NamedEnumMeta.names(NamedEnumMeta, False)
-        generator_tester(result, ('red', 'blue'))
-
-    def test_values(self, mocker):
-        mocker.patch.object(NamedEnumMeta, '_member_map_', create=True)
-        NamedEnumMeta._member_map_ = Color._member_map_
-
-        result = NamedEnumMeta.values(NamedEnumMeta, True)
-        assert result == (1, 2)
-
-        result = NamedEnumMeta.values(NamedEnumMeta, False)
-        generator_tester(result, (1, 2))
+    @pytest.mark.parametrize("as_tuple", [True, False])
+    @mock.patch.object(NamedEnumMeta, '_member_map_', create=True,
+                       new_callable=mock.PropertyMock(return_value=Color._member_map_))
+    def test_values(self, mocked__member_map_, as_tuple):
+        expected_result = (1, 2)
+        result = NamedEnumMeta.values(NamedEnumMeta, as_tuple)
+        if as_tuple:
+            assert result == expected_result
+        else:
+            generator_tester(result, expected_result)

--- a/tests/test_func_namedenum.py
+++ b/tests/test_func_namedenum.py
@@ -1,7 +1,6 @@
 import pytest
 import sys as _sys
-from pytest_mock import mocker
-
+from unittest import mock
 from named_enum import namedenum
 from collections import OrderedDict
 from .helper import generator_tester
@@ -17,68 +16,72 @@ class Triangle(TripleEnum):
 
 
 class TestNamedEnum:
-    def test_error(self, mocker):
-        mocker.patch.object(_sys, '_getframe')
-        _sys._getframe.side_effect = lambda value: AttributeError()
-        TripleFakeEnum = namedenum('TripleFakeEnum', ("first", "second", "third"), module=None)
+    @mock.patch.object(_sys, '_getframe', side_effect=AttributeError)
+    def test_error(self, mocked__getframe):
+        TripleFakeEnum = namedenum('TripleFakeEnum',
+                                   ("first", "second", "third"), module=None)
         assert TripleFakeEnum.__module__ == 'TripleFakeEnum'
-        _sys._getframe.assert_called_with(1)
+        mocked__getframe.assert_called_with(1)
 
-    def test__fields(self, mocker):
+    def test__fields(self):
         assert Triangle._fields() == ('first', 'second', 'third')
 
-        mocker.patch.object(Triangle, '_field_names_')
-        Triangle._field_names_ = None
-        assert Triangle._fields() == tuple()
+        with mock.patch.object(Triangle, '_field_names_',
+                               new_callable=mock.PropertyMock(return_value=None)) \
+                as mocked__field_names_:
+            assert Triangle._fields() == tuple()
 
-    def test_gen(self, mocker):
-        result = Triangle.gen(True)
-        expected_result = [
-            ('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)),
-            ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))]
+    @pytest.mark.parametrize("name_value_pair, expected_result",
+                             [(True, [('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)),
+                                      ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))]),
+                              (False, [Triangle.EQUILATERAL, Triangle.RIGHT])])
+    def test_gen(self, name_value_pair, expected_result):
+        result = Triangle.gen(name_value_pair)
         generator_tester(result, expected_result)
 
-        result = Triangle.gen(False)
-        expected_result = [Triangle.EQUILATERAL, Triangle.RIGHT]
-        generator_tester(result, expected_result)
+    @pytest.mark.parametrize('func_name, as_tuple, expected',
+                             [('firsts', True, (6, 3)),
+                              ('firsts', False, (6, 3)),
+                              ('seconds', True, (6, 4)),
+                              ('seconds', False, (6, 4)),
+                              ('thirds', True, (6, 5)),
+                              ('thirds', False, (6, 5))])
+    @mock.patch.object(Triangle, 'gen', side_effect=Triangle.gen)
+    def test__field_values(self, mocked_gen, func_name, as_tuple, expected):
+        result = getattr(Triangle, func_name)(as_tuple)
+        if as_tuple:
+            assert result == expected
+        else:
+            generator_tester(result, expected)
+        mocked_gen.assert_called_once_with(name_value_pair=False)
 
-    @pytest.mark.parametrize('func_name, expected',
-                             [('firsts', (6, 3)),
-                              ('seconds', (6, 4)),
-                              ('thirds', (6, 5))])
-    def test__field_values(self, mocker, func_name, expected):
-        mocker.spy(Triangle, 'gen')
-        result = getattr(Triangle, func_name)(True)
-        assert result == expected
-        assert Triangle.gen.call_count == 1
-        Triangle.gen.assert_called_with(name_value_pair=False)
-
-        result = getattr(Triangle, func_name)(False)
-        generator_tester(result, expected)
-        assert Triangle.gen.call_count == 2
-        Triangle.gen.assert_called_with(name_value_pair=False)
-
-    @pytest.mark.parametrize('func_name, value, expected',
-                             [('from_first', 6, (Triangle.EQUILATERAL, )),
-                              ('from_first', 3, (Triangle.RIGHT, )),
-                              ('from_first', 63, tuple()),
-                              ('from_second', 6, (Triangle.EQUILATERAL, )),
-                              ('from_second', 4, (Triangle.RIGHT, )),
-                              ('from_second', 64, tuple()),
-                              ('from_third', 6, (Triangle.EQUILATERAL, )),
-                              ('from_third', 5, (Triangle.RIGHT, )),
-                              ('from_third', 65, tuple())])
-    def test__from_field(self, mocker, func_name, value, expected):
-        mocker.spy(Triangle, 'gen')
-        result = getattr(Triangle, func_name)(value, True)
-        assert result == expected
-        assert Triangle.gen.call_count == 1
-        Triangle.gen.assert_called_with(name_value_pair=False)
-
-        result = getattr(Triangle, func_name)(value, False)
-        generator_tester(result, expected)
-        assert Triangle.gen.call_count == 2
-        Triangle.gen.assert_called_with(name_value_pair=False)
+    @pytest.mark.parametrize('func_name, value, as_tuple, expected',
+                             [('from_first', 6, True, (Triangle.EQUILATERAL, )),
+                              ('from_first', 6, False, (Triangle.EQUILATERAL,)),
+                              ('from_first', 3, True, (Triangle.RIGHT, )),
+                              ('from_first', 3, False, (Triangle.RIGHT, )),
+                              ('from_first', 63, True, tuple()),
+                              ('from_first', 63, False, tuple()),
+                              ('from_second', 6, True, (Triangle.EQUILATERAL, )),
+                              ('from_second', 6, False, (Triangle.EQUILATERAL, )),
+                              ('from_second', 4, True, (Triangle.RIGHT, )),
+                              ('from_second', 4, False, (Triangle.RIGHT, )),
+                              ('from_second', 64, True, tuple()),
+                              ('from_second', 64, False, tuple()),
+                              ('from_third', 6, True, (Triangle.EQUILATERAL, )),
+                              ('from_third', 6, False, (Triangle.EQUILATERAL, )),
+                              ('from_third', 5, True, (Triangle.RIGHT, )),
+                              ('from_third', 5, False, (Triangle.RIGHT, )),
+                              ('from_third', 65, True, tuple()),
+                              ('from_third', 65, False, tuple())])
+    @mock.patch.object(Triangle, 'gen', side_effect=Triangle.gen)
+    def test__from_field(self, mocked_gen, func_name, value, as_tuple, expected):
+        result = getattr(Triangle, func_name)(value, as_tuple)
+        if as_tuple:
+            assert result == expected
+        else:
+            generator_tester(result, expected)
+        mocked_gen.assert_called_once_with(name_value_pair=False)
 
     @pytest.mark.parametrize('func_name, value, expected',
                              [('has_first', 6, True),
@@ -90,12 +93,11 @@ class TestNamedEnum:
                               ('has_third', 6, True),
                               ('has_third', 5, True),
                               ('has_third', 65, False)])
-    def test__has_field(self, mocker, func_name, value, expected):
-        mocker.spy(Triangle, 'gen')
+    @mock.patch.object(Triangle, 'gen', side_effect=Triangle.gen)
+    def test__has_field(self, mocked_gen, func_name, value, expected):
         result = getattr(Triangle, func_name)(value)
         assert result == expected
-        assert Triangle.gen.call_count == 1
-        Triangle.gen.assert_called_with(name_value_pair=False)
+        mocked_gen.assert_called_once_with(name_value_pair=False)
 
     @pytest.mark.parametrize('func_name, func_param, error_type, error_msg',
                              [('forths', (True, ), AttributeError, 'forths'),
@@ -111,49 +113,61 @@ class TestNamedEnum:
         assert error_msg == str(excinfo.value)
 
     @pytest.mark.parametrize("data_type, expected",
-                             [(dict, {'EQUILATERAL': Triangle._tuple_cls(first=6, second=6, third=6), 'RIGHT': Triangle._tuple_cls(first=3, second=4, third=5)}),
-                              (list, [('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)), ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))]),
-                              (set, {('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)), ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))}),
-                              (tuple, (('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)), ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5)))),
-                              (OrderedDict, OrderedDict([('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)), ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))]))])
-    def test__as_data_type(self, mocker, data_type, expected):
-        mocker.spy(Triangle, 'gen')
+                             [(dict, {'EQUILATERAL': Triangle._tuple_cls(first=6, second=6, third=6),
+                                      'RIGHT': Triangle._tuple_cls(first=3, second=4, third=5)}),
+                              (list, [('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)),
+                                      ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))]),
+                              (set, {('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)),
+                                     ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))}),
+                              (tuple, (('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)),
+                                       ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5)))),
+                              (OrderedDict, OrderedDict([
+                                  ('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)),
+                                  ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))]))])
+    @mock.patch.object(Triangle, 'gen', side_effect=Triangle.gen)
+    def test__as_data_type(self, mocked_gen, data_type, expected):
         result = Triangle._as_data_type(data_type)
         assert result == expected
-        assert Triangle.gen.call_count == 1
-        Triangle.gen.assert_called_with()
+        mocked_gen.assert_called_once_with(name_value_pair=True)
 
     @pytest.mark.parametrize("func_name, expected",
-                             [("as_dict", {'EQUILATERAL': Triangle._tuple_cls(first=6, second=6, third=6), 'RIGHT': Triangle._tuple_cls(first=3, second=4, third=5)}),
-                              ("as_list", [('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)), ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))]),
-                              ("as_set", {('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)), ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))}),
-                              ("as_tuple", (('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)), ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5)))),
-                              ("as_ordereddict", OrderedDict([('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)), ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))]))])
-    def test_as_x(self, mocker, func_name, expected):
-        mocker.spy(Triangle, '_as_data_type')
+                             [("as_dict", {'EQUILATERAL': Triangle._tuple_cls(first=6, second=6, third=6),
+                                           'RIGHT': Triangle._tuple_cls(first=3, second=4, third=5)}),
+                              ("as_list", [('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)),
+                                           ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))]),
+                              ("as_set", {('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)),
+                                          ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))}),
+                              ("as_tuple", (('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)),
+                                            ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5)))),
+                              ("as_ordereddict", OrderedDict([
+                                  ('EQUILATERAL', Triangle._tuple_cls(first=6, second=6, third=6)),
+                                  ('RIGHT', Triangle._tuple_cls(first=3, second=4, third=5))]))])
+    @mock.patch.object(Triangle, '_as_data_type', side_effect=Triangle._as_data_type)
+    def test_as_x(self, mocked__as_data_type, func_name, expected):
         result = getattr(Triangle, func_name)()
         assert result == expected
-        assert Triangle._as_data_type.call_count == 1
-        Triangle._as_data_type.assert_called_with(type(expected))
+        mocked__as_data_type.assert_called_once_with(type(expected))
 
-    def test___repr__(self, mocker):
-        mocker.spy(type(Triangle), '__repr__')
+    @mock.patch.object(type(Triangle), "__repr__",
+                       side_effect=type(Triangle).__repr__, autospec=True)
+    def test___repr__(self, mocked_repr):
         assert repr(Triangle) == "<named enum 'Triangle'>"
-        assert type(Triangle).__repr__.call_count == 1
+        assert mocked_repr.call_count == 1
         assert str(Triangle) == "<named enum 'Triangle'>"
-        assert type(Triangle).__repr__.call_count == 2
+        assert mocked_repr.call_count == 2
 
-    def test___str__(self, mocker):
-        mocker.spy(Triangle, '__str__')
+    @mock.patch.object(Triangle, "__str__", side_effect=Triangle.__str__,
+                       autospec=True)
+    def test___str__(self, mocked_str):
         result = str(Triangle.RIGHT)
         assert result == "Triangle.RIGHT: NamedTuple(first=3, second=4, " \
                          "third=5)"
-        assert Triangle.__str__.call_count == 1
+        assert mocked_str.call_count == 1
 
         result = str(Triangle.EQUILATERAL)
         assert result == "Triangle.EQUILATERAL: NamedTuple(first=6, second=6, " \
                          "third=6)"
-        assert Triangle.__str__.call_count == 2
+        assert mocked_str.call_count == 2
 
     def test_describe(self, capsys):
         Triangle.describe()
@@ -163,21 +177,24 @@ class TestNamedEnum:
                       "    6 |      6 |     6\n      RIGHT |     3 |      4 |" \
                       "     5\n\n"
 
-    def test_names(self, mocker):
-        result = Triangle.names(True)
-        assert result == ('EQUILATERAL', 'RIGHT')
+    @pytest.mark.parametrize("as_tuple", [True, False])
+    def test_names(self, as_tuple):
+        expected_result = ('EQUILATERAL', 'RIGHT')
+        result = Triangle.names(as_tuple)
+        if as_tuple:
+            assert result == expected_result
+        else:
+            generator_tester(result, expected_result)
 
-        result = Triangle.names(False)
-        generator_tester(result, ('EQUILATERAL', 'RIGHT'))
-
-    def test_values(self, mocker):
-        expected = (Triangle._tuple_cls(first=6, second=6, third=6),
-                    Triangle._tuple_cls(first=3, second=4, third=5))
-        result = Triangle.values(True)
-        assert result == expected
-
-        result = Triangle.values(False)
-        generator_tester(result, expected)
+    @pytest.mark.parametrize("as_tuple", [True, False])
+    def test_values(self, as_tuple):
+        expected_result = (Triangle._tuple_cls(first=6, second=6, third=6),
+                           Triangle._tuple_cls(first=3, second=4, third=5))
+        result = Triangle.values(as_tuple)
+        if as_tuple:
+            assert result == expected_result
+        else:
+            generator_tester(result, expected_result)
 
     def test___getattr__(self):
         result = getattr(Triangle.RIGHT, 'first')


### PR DESCRIPTION
1. Remove pytest-mock from test-requirements.txt and adapt corresponding tests; 
2. Add generator type check in generator_tester function in helper.py; 
3. Pass name_value_pair=True explicitly in NamedEnumMeta's _as_data_type function