### PR TITLE
Feature for python 3.8

### DIFF
--- a/named_enum/__init__.py
+++ b/named_enum/__init__.py
@@ -18,8 +18,7 @@ __all__ = [
 
 
 class _NamedEnumDict(_EnumDict):
-    """
-    Customizes _EnumDict, such that it allows setting the value for the keyword
+    """Customizes _EnumDict, such that it allows setting the value for the keyword
     '_field_names_' and provides the functions for cleaning itself and
     converting the collection type value (except str) to NamedTuple type.
     """
@@ -39,8 +38,7 @@ class _NamedEnumDict(_EnumDict):
             super().__setitem__(key, value)
 
     def _clean(self):
-        """
-        Removes all the items, and set the variables '_member_names' and
+        """Removes all the items, and set the variables '_member_names' and
         '_last_values' to empty.
         """
         # for dictionary, that's the only way to _clean it
@@ -50,8 +48,7 @@ class _NamedEnumDict(_EnumDict):
         self._member_names, self._last_values = [], []
 
     def _convert(self, tuple_cls):
-        """
-        Uses the given tuple class to _convert the items.
+        """Uses the given tuple class to _convert the items.
 
         :param tuple_cls: using namedtuple generated
           tuple class
@@ -86,8 +83,7 @@ class _NamedEnumDict(_EnumDict):
 
 
 class NamedEnumMeta(EnumMeta):
-    """
-    Extends the `EnumMeta` class for three purposes:
+    """Extends the `EnumMeta` class for three purposes:
 
     1.  uses the `_NamedEnumDict` as the data type of the `namespace` parameter
     for `__new__` function, such that we can use the `namedtuple` as the data
@@ -106,8 +102,7 @@ class NamedEnumMeta(EnumMeta):
     """
     @classmethod
     def __prepare__(mcs, cls, bases):
-        """
-        Namespace hook, uses _NamedEnumDict as the type of namespace instead of
+        """Namespace hook, uses _NamedEnumDict as the type of namespace instead of
         _EnumDict.
 
         :param cls: name of the class to create
@@ -127,8 +122,7 @@ class NamedEnumMeta(EnumMeta):
         return enum_dict
 
     def __new__(mcs, name, bases, namespace):
-        """
-        Besides the class creation, this function also intends to create a named
+        """Besides the class creation, this function also intends to create a named
         tuple data type depending on the given value of '_field_names_' variable
         to be the data type of the value of enumeration iem and add those extra
         functions to the class.
@@ -195,9 +189,21 @@ class NamedEnumMeta(EnumMeta):
             cls = super().__new__(mcs, name, bases, namespace)
         return cls
 
-    def _fields(cls):
+    def __contains__(cls, member):
+        """Overrides the magic method in Enum class, which doesn't support
+        member name search from python 3.8.
+
+        :param member: the lookup value
+        :type member: str | Enum class
+        :return: if the member is contained in the enumeration.
+        :rtype: bool
         """
-        Returns the defined field names as a `tuple` for the enumeration class.
+        if isinstance(member, str):
+            return member in cls._member_map_
+        return isinstance(member, cls) and member._name_ in cls._member_map_
+
+    def _fields(cls):
+        """Returns the defined field names as a `tuple` for the enumeration class.
 
         If the variable `_field_names_` is `None` or empty value, then
         returns an empty `tuple`.
@@ -221,8 +227,7 @@ class NamedEnumMeta(EnumMeta):
 
     @classmethod
     def _field_values(mcs, cls, field_name, as_tuple=True):
-        """
-        Base function returns a `tuple`/`generator` containing just the value of the
+        """Base function returns a `tuple`/`generator` containing just the value of the
         given field_name of all the elements from the cls.
 
         It's used to generate the particular function with name format
@@ -244,8 +249,7 @@ class NamedEnumMeta(EnumMeta):
 
     @classmethod
     def _from_field(mcs, cls, field_name, field_value, as_tuple=True):
-        """
-        Base function returns a `tuple` of the defined enumeration items
+        """Base function returns a `tuple` of the defined enumeration items
         regarding to the given `field_value` of field with `field_name`, if
         `as_tuple` is True; otherwise returns a generator.
 
@@ -270,8 +274,7 @@ class NamedEnumMeta(EnumMeta):
 
     @classmethod
     def _has_field(mcs, cls, field_name, field_value):
-        """
-        Base function returns a boolean value which indicates if there is at
+        """Base function returns a boolean value which indicates if there is at
         least one enumeration item in which the value of the field `field_name`
         corresponding value matches the given `field_value`.
 
@@ -291,8 +294,7 @@ class NamedEnumMeta(EnumMeta):
         return field_value in gen_field_values
 
     def gen(cls, name_value_pair=True):
-        """
-        Returns a generator of pairs consisting of each enumeration item's name
+        """Returns a generator of pairs consisting of each enumeration item's name
         and value, if name_value_pair is True; otherwise a generator of the
         enumeration items.
 
@@ -331,8 +333,7 @@ class NamedEnumMeta(EnumMeta):
         return (item for name, item in cls._member_map_.items())
 
     def _as_data_type(cls, data_type):
-        """
-        Base function converts the enumeration class to the given data type
+        """Base function converts the enumeration class to the given data type
         value.
 
         It's used for generating the functions like `as_dict`, `as_tuple`,
@@ -348,8 +349,7 @@ class NamedEnumMeta(EnumMeta):
         return data_type(cls.gen(name_value_pair=True))
 
     def as_dict(cls):
-        """
-        Converts the enumeration to a `dict`, in which the key is the name
+        """Converts the enumeration to a `dict`, in which the key is the name
         of the enumeration item and value is its value.
 
         :return: a dictionary containing name-value-pairs of the enumeration

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -22,6 +22,9 @@ def spy(obj, name):
 class CommonEnumTest:
     enum_cls = None
 
+    def test___contains__(self, checked_member, expected):
+        assert (checked_member in self.enum_cls) == expected
+
     def test__fields(self, expected_normal_output):
         assert self.enum_cls._fields() == expected_normal_output
 

--- a/tests/test_cls_ExtendedEnum.py
+++ b/tests/test_cls_ExtendedEnum.py
@@ -14,6 +14,14 @@ class TestExtendedEnum(CommonEnumTest):
     enum_cls = TVCouple
     # a map specifying multiple argument sets for a test method
     params = {
+        "test___contains__": [
+            dict(checked_member="GALLAGHERS", expected=True),
+            dict(checked_member="MIKE_AND_MOLLY", expected=True),
+            dict(checked_member="TOM_AND_JERRY", expected=False),
+            dict(checked_member=TVCouple.GALLAGHERS, expected=True),
+            dict(checked_member=TVCouple.MIKE_AND_MOLLY, expected=True),
+            dict(checked_member=TVCouple, expected=False),
+            dict(checked_member=ExtendedEnum, expected=False)],
         "test__fields": [dict(expected_normal_output=tuple())],
         "test_gen": [
             dict(name_value_pair=True,

--- a/tests/test_cls_LabeledEnum.py
+++ b/tests/test_cls_LabeledEnum.py
@@ -13,6 +13,14 @@ class TestLabeledEnum(CommonEnumTest, ExtraEnumTest):
     enum_cls = NBALegendary
     # a map specifying multiple argument sets for a test method
     params = {
+        "test___contains__": [
+            dict(checked_member="JOHNSON", expected=True),
+            dict(checked_member="Jordan", expected=True),
+            dict(checked_member="TOM_AND_JERRY", expected=False),
+            dict(checked_member=NBALegendary.JOHNSON, expected=True),
+            dict(checked_member=NBALegendary.Jordan, expected=True),
+            dict(checked_member=NBALegendary, expected=False),
+            dict(checked_member=LabeledEnum, expected=False)],
         "test__fields": [dict(expected_normal_output=('key', 'label'))],
         "test_gen": [
             dict(name_value_pair=True,

--- a/tests/test_cls_NamedEnum.py
+++ b/tests/test_cls_NamedEnum.py
@@ -18,6 +18,14 @@ class TestNamedEnum(CommonEnumTest, ExtraEnumTest):
     enum_cls = Triangle
     # a map specifying multiple argument sets for a test method
     params = {
+        "test___contains__": [
+            dict(checked_member="EQUILATERAL", expected=True),
+            dict(checked_member="RIGHT", expected=True),
+            dict(checked_member="TOM_AND_JERRY", expected=False),
+            dict(checked_member=Triangle.EQUILATERAL, expected=True),
+            dict(checked_member=Triangle.RIGHT, expected=True),
+            dict(checked_member=Triangle, expected=False),
+            dict(checked_member=TripleEnum, expected=False)],
         "test__fields": [dict(expected_normal_output=('first', 'second', 'third'))],
         "test_gen": [
             dict(name_value_pair=True,

--- a/tests/test_cls_NamedEnumMeta.py
+++ b/tests/test_cls_NamedEnumMeta.py
@@ -39,6 +39,19 @@ class TestNamedEnumMeta:
         assert result == expected_result
         mocked__get_mixins_.assert_called_once_with(tuple())
 
+    @pytest.mark.parametrize('checked_member, expected',
+                             [("red", True),
+                              ("blue", True),
+                              ("yellow", False),
+                              (Color.red, True),
+                              (Color.blue, True),
+                              (Color, False),
+                              (NamedEnumMeta, False)])
+    @mock.patch.object(Enum, '_member_map_', create=True,
+                       new_callable=mock.PropertyMock(return_value=Color._member_map_))
+    def test___contains__(self, mocked__member_map_, checked_member, expected):
+        assert NamedEnumMeta.__contains__(Enum, checked_member) == expected
+
     @pytest.mark.parametrize('_field_names_, expected',
                              [(None, tuple()),
                               ("ha", ('key', 'value'))])

--- a/tests/test_cls_PairEnum.py
+++ b/tests/test_cls_PairEnum.py
@@ -13,6 +13,14 @@ class TestPairEnum(CommonEnumTest, ExtraEnumTest):
     enum_cls = Pair
     # a map specifying multiple argument sets for a test method
     params = {
+        "test___contains__": [
+            dict(checked_member="TOM_AND_JERRY", expected=True),
+            dict(checked_member="MIKE_AND_MOLLY", expected=True),
+            dict(checked_member="GALLAGHERS", expected=False),
+            dict(checked_member=Pair.TOM_AND_JERRY, expected=True),
+            dict(checked_member=Pair.MIKE_AND_MOLLY, expected=True),
+            dict(checked_member=Pair, expected=False),
+            dict(checked_member=PairEnum, expected=False)],
         "test__fields": [dict(expected_normal_output=('first', 'second'))],
         "test_gen": [
             dict(name_value_pair=True,

--- a/tests/test_func_namedenum.py
+++ b/tests/test_func_namedenum.py
@@ -19,6 +19,14 @@ class TestNamedEnumFunc(CommonEnumTest, ExtraEnumTest):
     enum_cls = Triangle
     # a map specifying multiple argument sets for a test method
     params = {
+        "test___contains__": [
+            dict(checked_member="EQUILATERAL", expected=True),
+            dict(checked_member="RIGHT", expected=True),
+            dict(checked_member="TOM_AND_JERRY", expected=False),
+            dict(checked_member=Triangle.EQUILATERAL, expected=True),
+            dict(checked_member=Triangle.RIGHT, expected=True),
+            dict(checked_member=Triangle, expected=False),
+            dict(checked_member=TripleEnum, expected=False)],
         "test__fields": [dict(expected_normal_output=('first', 'second', 'third'))],
         "test_gen": [
             dict(name_value_pair=True,


### PR DESCRIPTION
Add enum name check for python 3.8, since this feature is deprecated in 3.8