### PR TITLE
Bug fix and clean pytest.ini

### DIFF
--- a/named_enum/__init__.py
+++ b/named_enum/__init__.py
@@ -115,7 +115,12 @@ class NamedEnumMeta(EnumMeta):
         # create the namespace dict
         enum_dict = _NamedEnumDict()
         # inherit previous flags and _generate_next_value_ function
-        member_type, first_enum = mcs._get_mixins_(bases)
+        if _sys.version_info >= (3, 8):
+            enum_dict._cls_name = cls
+            # inherit previous flags and _generate_next_value_ function
+            member_type, first_enum = mcs._get_mixins_(cls, bases)
+        else:
+            member_type, first_enum = mcs._get_mixins_(bases)
         if first_enum is not None:
             enum_dict['_generate_next_value_'] = getattr(
                 first_enum, '_generate_next_value_', None)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,0 @@
-[pytest]
-doctest_encoding = latin1
-testpaths = tests
-addopts =
-  --verbose
-  --doctest-modules
-  --doctest-glob=tests/*.txt
-  --cov=named_enum --cov-report=xml tests/

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,5 +5,15 @@ exclude =
     __pycache__,
     build,
     dist
+
+[tool:pytest]
+doctest_encoding = latin1
+testpaths = tests
+addopts =
+  --verbose
+  --doctest-modules
+  --doctest-glob=tests/*.txt
+  --cov=named_enum --cov-report=xml tests/
+
 [aliases]
 test=pytest


### PR DESCRIPTION
1. fixed issue, where the package is incompatible with python 3.8 due to changed signature of function _get_mixins_ in class EnumMeta. (Closes #66)
2. merged pytest.ini into setup.cfg